### PR TITLE
Switch away from deprecated setup-android

### DIFF
--- a/.github/workflows/androidCi.yml
+++ b/.github/workflows/androidCi.yml
@@ -10,6 +10,4 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: setup-android
-      uses: msfjarvis/setup-android@0.2
-      with:
-        gradleTasks: clean publishToMavenLocal
+      run: ./gradlew clean publishToMavenLocal


### PR DESCRIPTION
I am in the process of deprecating setup-android as GitHub Actions now ships default containers with everything that's needed.
﻿﻿